### PR TITLE
update react-native-tensorio to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "TensorIOExample",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8436,9 +8436,9 @@
       "integrity": "sha512-lQfdOyC1mQ/pvfEaUGdoodO1A1clg9kf6YC1WdbWhA6XK+joBd9GQYf8SaCf6/7vM25U4ib+6ux4yvnrS1pOqQ=="
     },
     "react-native-tensorio": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-tensorio/-/react-native-tensorio-0.1.0.tgz",
-      "integrity": "sha512-nAbX4fT3/cQsDo+MwuGDFzozSq3p7vGes54iIWnBoCikb6ol8fQwlX5K2buF3JfrEQEx7Cb1MtLOGDyKOYj8Ig=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-tensorio/-/react-native-tensorio-0.1.2.tgz",
+      "integrity": "sha512-MWiz9z07dHA4ayvRRDCjq9YCQYwhDpVawaJiMxf5EPGlt048eY5O8djdCqwTDuXMOtgKe3QU0jzNJ2vmweEtCw=="
     },
     "react-proxy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react": "16.6.3",
     "react-native": "0.58.4",
     "react-native-image-picker": "^0.28.0",
-    "react-native-tensorio": "^0.1.0"
+    "react-native-tensorio": "^0.1.2"
   },
   "devDependencies": {
     "babel-core": "7.0.0-bridge.0",


### PR DESCRIPTION
fixes lock file to use 0.1.2, which addresses changes in tensorio v0.4